### PR TITLE
Similar request error handling fix to #167 for remaining requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![mailchimp3 v3.0.7 on PyPi](https://img.shields.io/pypi/v/mailchimp3.svg)](https://pypi.python.org/pypi/mailchimp3)
+[![mailchimp3 v3.0.8 on PyPi](https://img.shields.io/pypi/v/mailchimp3.svg)](https://pypi.python.org/pypi/mailchimp3)
 ![MIT license](https://img.shields.io/badge/licence-MIT-blue.svg)
 ![Stable](https://img.shields.io/badge/status-stable-green.svg)
 

--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-|mailchimp3 v3.0.7 on PyPi| |MIT license| |Stable|
+|mailchimp3 v3.0.8 on PyPi| |MIT license| |Stable|
 
 python-mailchimp-api
 ====================

--- a/mailchimp3/mailchimpclient.py
+++ b/mailchimp3/mailchimpclient.py
@@ -35,6 +35,15 @@ class MailChimpError(Exception):
     pass
 
 
+def _raise_response_error(r):
+    # in case of a 500 error, the response might not be a JSON
+    try:
+        error_data = r.json()
+    except ValueError:
+        error_data = { "response": r }
+    raise MailChimpError(error_data)
+
+
 class MailChimpClient(object):
     """
     MailChimp class to communicate with the v3 API
@@ -123,12 +132,8 @@ class MailChimpClient(object):
             raise e
         else:
             if r.status_code >= 400:
-                # in case of a 500 error, the response might not be a JSON
-                try:
-                    error_data = r.json()
-                except ValueError:
-                    error_data = { "response": r }
-                raise MailChimpError(error_data)
+                _raise_response_error(r)
+
             if r.status_code == 204:
                 return None
             return r.json()
@@ -160,7 +165,7 @@ class MailChimpClient(object):
             raise e
         else:
             if r.status_code >= 400:
-                raise MailChimpError(r.json())
+                _raise_response_error(r)
             return r.json()
 
 
@@ -187,7 +192,7 @@ class MailChimpClient(object):
             raise e
         else:
             if r.status_code >= 400:
-                raise MailChimpError(r.json())
+                _raise_response_error(r)
             if r.status_code == 204:
                 return
             return r.json()
@@ -219,7 +224,7 @@ class MailChimpClient(object):
             raise e
         else:
             if r.status_code >= 400:
-                raise MailChimpError(r.json())
+                _raise_response_error(r)
             return r.json()
 
 
@@ -249,12 +254,7 @@ class MailChimpClient(object):
             raise e
         else:
             if r.status_code >= 400:
-                # in case of 500 error, the response might not be a JSON
-                try:
-                    error_data = r.json()
-                except ValueError:
-                    error_data = { "response": r }
-                raise MailChimpError(error_data)
+                _raise_response_error(r)
             return r.json()
 
 

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ except Exception:
 
 setup(
     name='mailchimp3',
-    version='3.0.7',
+    version='3.0.8',
     description='A python client for v3 of MailChimp API',
     long_description=long_description,
     url='https://github.com/charlesthk/python-mailchimp',


### PR DESCRIPTION
I am getting `JSONDecodeError` messages when receiving a 504 response in `def _get` [here](https://github.com/VingtCinq/python-mailchimp/blob/master/mailchimp3/mailchimpclient.py#L163) similar to #167. This implements the same fix that is in 3377ea9 and 95f1edc for other requests.