### PR TITLE
Remove hardcoded 1000 count for BaseApi._iterate

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![mailchimp3 v3.0.8 on PyPi](https://img.shields.io/pypi/v/mailchimp3.svg)](https://pypi.python.org/pypi/mailchimp3)
+[![mailchimp3 v3.0.9 on PyPi](https://img.shields.io/pypi/v/mailchimp3.svg)](https://pypi.python.org/pypi/mailchimp3)
 ![MIT license](https://img.shields.io/badge/licence-MIT-blue.svg)
 ![Stable](https://img.shields.io/badge/status-stable-green.svg)
 
@@ -57,22 +57,21 @@ access key can be found
 
 ### Pagination
 
-Simply add `count` and `offset` arguments in your function. The count
-is how many records to return, the offset is how many records to skip.
-For endpoints that allow the pagination parameters, the all() method
-has an additional boolean `get_all` argument that will loop through all
-records until the API no longer returns any to get all records without
-manually performing an additional query. By default, count is 10 and
-offset is 0 for all endpoints that support it. The `get_all` parameter
-on the all() method on any endpoint defaults to false, which follows
-the values that are provided in the call, and using `get_all=True` will
-ignore the provided count and offset to ensure that all records are
-returned. When using get_all, the count will be 5000, to fetch large
-numbers of records without flooding the system with requests. The large
-size of count should not impact calls which are expected to return a
-very small number of records, and should improve performance for calls
-where fetching 5000 records would only provide a fraction by preventing
-the delay of making a huge number of requests.
+Simply add `count` and `offset` arguments in your function. The count is how
+many records to return, the offset is how many records to skip. For endpoints
+that allow the pagination parameters, the all() method has an additional boolean
+`get_all` argument that will loop through all records until the API no longer
+returns any to get all records without manually performing an additional query.
+By default, count is 10 and offset is 0 for all endpoints that support it. The
+`get_all` parameter on the all() method on any endpoint defaults to false, which
+follows the values that are provided in the call, and using `get_all=True` will
+ignore the provided offset to ensure that all records are returned. When using
+get_all, the count will be 500 unless otherwise specified. It is strongly
+recommended to avoid small values for `count` to fetch large numbers of records
+because this will flood the system. A large `count` size should not impact calls
+which are expected to return a very small number of records, and should improve
+performance for calls where fetching 500 records would only provide a fraction
+by preventing the delay of making a huge number of requests.
 
     client.lists.members.all('123456', count=100, offset=0)
 

--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-|mailchimp3 v3.0.8 on PyPi| |MIT license| |Stable|
+|mailchimp3 v3.0.9 on PyPi| |MIT license| |Stable|
 
 python-mailchimp-api
 ====================
@@ -67,22 +67,21 @@ access key can be found
 Pagination
 ~~~~~~~~~~
 
-Simply add ``count`` and ``offset`` arguments in your function. The
-count is how many records to return, the offset is how many records to
-skip. For endpoints that allow the pagination parameters, the all()
-method has an additional boolean ``get_all`` argument that will loop
-through all records until the API no longer returns any to get all
-records without manually performing an additional query. By default,
-count is 10 and offset is 0 for all endpoints that support it. The
-``get_all`` parameter on the all() method on any endpoint defaults to
-false, which follows the values that are provided in the call, and using
-``get_all=True`` will ignore the provided count and offset to ensure
-that all records are returned. When using get_all, the count will be
-5000, to fetch large numbers of records without flooding the system with
-requests. The large size of count should not impact calls which are
-expected to return a very small number of records, and should improve
-performance for calls where fetching 5000 records would only provide a
-fraction by preventing the delay of making a huge number of requests.
+Simply add ``count`` and ``offset`` arguments in your function. The count is how
+many records to return, the offset is how many records to skip. For endpoints
+that allow the pagination parameters, the all() method has an additional boolean
+``get_all`` argument that will loop through all records until the API no longer
+returns any to get all records without manually performing an additional query.
+By default, count is 10 and offset is 0 for all endpoints that support it. The
+``get_all`` parameter on the all() method on any endpoint defaults to false, which
+follows the values that are provided in the call, and using ``get_all=True`` will
+ignore the provided offset to ensure that all records are returned. When using
+get_all, the count will be 500 unless otherwise specified. It is strongly
+recommended to avoid small values for ``count`` to fetch large numbers of records
+because this will flood the system. A large ``count`` size should not impact calls
+which are expected to return a very small number of records, and should improve
+performance for calls where fetching 500 records would only provide a fraction
+by preventing the delay of making a huge number of requests.
 
 ::
 

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ except Exception:
 
 setup(
     name='mailchimp3',
-    version='3.0.8',
+    version='3.0.9',
     description='A python client for v3 of MailChimp API',
     long_description=long_description,
     url='https://github.com/charlesthk/python-mailchimp',


### PR DESCRIPTION
As mentioned in https://github.com/VingtCinq/python-mailchimp/pull/207, sometimes using `count=1000` leads to `504 - gateway timeout` errors when hitting an api endpoint. Mailchimp support suggests using a lower count number when you start to receive these errors. Unfortunately, count is hardcoded to 1000 and cannot be changed when using `get_all=True`.

This patch modifies the default behavior such that when `get_all=True`, a user-supplied `count` is used. If `count` is not supplied by the call, then it defaults to 1000.