### PR TITLE
Remove logging of raw responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![mailchimp3 v3.0.9 on PyPi](https://img.shields.io/pypi/v/mailchimp3.svg)](https://pypi.python.org/pypi/mailchimp3)
+[![mailchimp3 v3.0.10 on PyPi](https://img.shields.io/pypi/v/mailchimp3.svg)](https://pypi.python.org/pypi/mailchimp3)
 ![MIT license](https://img.shields.io/badge/licence-MIT-blue.svg)
 ![Stable](https://img.shields.io/badge/status-stable-green.svg)
 

--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-|mailchimp3 v3.0.9 on PyPi| |MIT license| |Stable|
+|mailchimp3 v3.0.10 on PyPi| |MIT license| |Stable|
 
 python-mailchimp-api
 ====================
@@ -925,7 +925,7 @@ License
 
 The project is licensed under the MIT License.
 
-.. |mailchimp3 v3.0.9 on PyPi| image:: https://img.shields.io/pypi/v/mailchimp3.svg
+.. |mailchimp3 v3.0.10 on PyPi| image:: https://img.shields.io/pypi/v/mailchimp3.svg
    :target: https://pypi.python.org/pypi/mailchimp3
 .. |MIT license| image:: https://img.shields.io/badge/licence-MIT-blue.svg
 .. |Stable| image:: https://img.shields.io/badge/status-stable-green.svg

--- a/mailchimp3/mailchimpclient.py
+++ b/mailchimp3/mailchimpclient.py
@@ -100,8 +100,8 @@ class MailChimpClient(object):
 
         response = requests.request(**kwargs)
 
-        _logger.info(u'{method} Response: {status} {text}'\
-            .format(method=kwargs['method'], status=response.status_code, text=response.text))
+        _logger.info(u'{method} Response: {status}'\
+            .format(method=kwargs['method'], status=response.status_code))
 
         return response
 

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ except Exception:
 
 setup(
     name='mailchimp3',
-    version='3.0.9',
+    version='3.0.10',
     description='A python client for v3 of MailChimp API',
     long_description=long_description,
     url='https://github.com/charlesthk/python-mailchimp',


### PR DESCRIPTION
This update removes the response text from the logging action taken by the logger after a request is made to prevent runaway log file sizes. I have seen that recording the raw response text on certain large queries can cause log files to very quickly become massive and fill server drives, an obvious bad problem. We might want to add a note near the top of the README files that recommends that everyone update to 3.0.10+ due to this potential issue, but I will leave that as a suggestion instead of adding it to the README at the start of this update.