### PR TITLE
Add activity-feed endpoint in listmemberactivity

### DIFF
--- a/mailchimp3/entities/listmemberactivity.py
+++ b/mailchimp3/entities/listmemberactivity.py
@@ -46,8 +46,9 @@ class ListMemberActivity(BaseApi):
     
     def feed(self, list_id, subscriber_hash, **queryparams):
         """
-        Get the last 50 events of a member’s activity on a specific list,
-        including opens, clicks, and unsubscribes.
+        Get the last 10 events of a member’s activity on a specific list,
+        including opens, clicks, and unsubscribes. 
+        With count parameter, get as many past events as you would like.
 
         :param list_id: The unique id for the list.
         :type list_id: :py:class:`str`

--- a/mailchimp3/entities/listmemberactivity.py
+++ b/mailchimp3/entities/listmemberactivity.py
@@ -43,3 +43,23 @@ class ListMemberActivity(BaseApi):
         self.list_id = list_id
         self.subscriber_hash = subscriber_hash
         return self._mc_client._get(url=self._build_path(list_id, 'members', subscriber_hash, 'activity'), **queryparams)
+    
+    def feed(self, list_id, subscriber_hash, **queryparams):
+        """
+        Get the last 50 events of a member’s activity on a specific list,
+        including opens, clicks, and unsubscribes.
+
+        :param list_id: The unique id for the list.
+        :type list_id: :py:class:`str`
+        :param subscriber_hash: The MD5 hash of the lowercase version of the
+          list member’s email address.
+        :type subscriber_hash: :py:class:`str`
+        :param queryparams: The query string parameters
+        queryparams['fields'] = []
+        queryparams['exclude_fields'] = []
+        """
+        subscriber_hash = check_subscriber_hash(subscriber_hash)
+        self.list_id = list_id
+        self.subscriber_hash = subscriber_hash
+        return self._mc_client._get(url=self._build_path(list_id, 'members', subscriber_hash, 'activity-feed'), **queryparams)
+

--- a/mailchimp3/entities/listmemberactivity.py
+++ b/mailchimp3/entities/listmemberactivity.py
@@ -49,6 +49,7 @@ class ListMemberActivity(BaseApi):
         Get the last 10 events of a member’s activity on a specific list,
         including opens, clicks, and unsubscribes. 
         With count parameter, get as many past events as you would like.
+        Returns many more fields not accessible by all endpoint.
 
         :param list_id: The unique id for the list.
         :type list_id: :py:class:`str`


### PR DESCRIPTION
Can get more than 50 events as compared to activity.all and a lot more information as well.