### PR TITLE
Fix wrong path for getting all promo-rules

### DIFF
--- a/mailchimp3/entities/storepromorules.py
+++ b/mailchimp3/entities/storepromorules.py
@@ -76,7 +76,7 @@ class StorePromoRules(BaseApi):
         if get_all:
             return self._iterate(url=self._build_path(store_id, 'promo-rules'), **queryparams)
         else:
-            return self._mc_client._get(url=self._build_path(store_id, 'promo-rule'), **queryparams)
+            return self._mc_client._get(url=self._build_path(store_id, 'promo-rules'), **queryparams)
 
     def get(self, store_id, promo_rule_id, **queryparams):
         """

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ except Exception:
 
 setup(
     name='mailchimp3',
-    version='3.0.14',
+    version='3.0.15',
     description='A python client for v3 of MailChimp API',
     long_description=long_description,
     url='https://github.com/charlesthk/python-mailchimp',


### PR DESCRIPTION
I was getting an error using `client.stores.promo_rules.all(store_id=store_id, get_all=False, **{"count": 1})` and after investigating I found a typo in the path appendix for `promo_rules.all`.

Hope that helps! Thanks for the great library.